### PR TITLE
socket listen is no more experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ To build into the example `npm install` and `npm install -g grunt` then `grunt`
 Testing the example
 -------------------
 
-1.  Launch Chrome Canary or Dev Channel (v24).
+1.  Launch Google Chrome (at least v24).
 2.  Visit chrome://extensions
 3.  Enable Developer mode.
 4.  Load unpacked extension from examples/http

--- a/example/debug/manifest.json
+++ b/example/debug/manifest.json
@@ -13,5 +13,5 @@
       "scripts": ["main.js"]
     }
   },
-  "permissions": ["experimental", {"socket":["tcp-listen"]}]
+  "permissions": [{"socket":["tcp-listen"]}]
 }

--- a/example/http/manifest.json
+++ b/example/http/manifest.json
@@ -13,5 +13,5 @@
       "scripts": ["main.js"]
     }
   },
-  "permissions": ["experimental", {"socket":["tcp-listen"]}]
+  "permissions": [{"socket":["tcp-listen"]}]
 }

--- a/example/http/node.js
+++ b/example/http/node.js
@@ -927,7 +927,7 @@ net.Socket.prototype.setEncoding = function(encoding) {
 
 net.Socket.prototype.setNoDelay = function(noDelay) {
   noDelay = (noDelay === undefined) ? true : noDelay;
-  chrome.socket.setNoDely(self._socketInfo.socketId, noDelay, function() {});
+  chrome.socket.setNoDelay(self._socketInfo.socketId, noDelay, function() {});
 };
 
 net.Socket.prototype.setKeepAlive = function(enable, delay) {

--- a/example/http/node.js
+++ b/example/http/node.js
@@ -927,7 +927,7 @@ net.Socket.prototype.setEncoding = function(encoding) {
 
 net.Socket.prototype.setNoDelay = function(noDelay) {
   noDelay = (noDelay === undefined) ? true : noDelay;
-  chrome.socket.setNoDelay(self._socketInfo.socketId, noDelay, function() {});
+  chrome.socket.setNoDely(self._socketInfo.socketId, noDelay, function() {});
 };
 
 net.Socket.prototype.setKeepAlive = function(enable, delay) {

--- a/example/post/manifest.json
+++ b/example/post/manifest.json
@@ -13,5 +13,5 @@
       "scripts": ["main.js"]
     }
   },
-  "permissions": ["experimental", {"socket":["tcp-listen"]}]
+  "permissions": [{"socket":["tcp-listen"]}]
 }


### PR DESCRIPTION
The chrome socket tcp-listen api is no more an experimental api.
Additional infos:
http://developer.chrome.com/apps/socket.html
http://developer.chrome.com/apps/app_network.html
